### PR TITLE
Rebuild pydot 1.4.1 on ppc64le for Python 3.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  # trigger: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:


### PR DESCRIPTION
pydot 1.4.1 is missing for Python 3.9 on ppc64le.